### PR TITLE
Replicate Fig.4-Right Experiment, Fix bug in Binary Leg F1-Score calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,52 @@
-This repository holds the preliminary code of the submission to ICRL 2023: `On discrete symmetries of robotic systems: A data-driven and group-theoretic analysis`
+# MorphoSymm Contact Experiment Replication
 
-**The code to this anonymous repository is made available only to Area/Program chairs and reviewers**, not to any user of OpenReview. We kindly ask you **NOT TO SHARE** this link to any third parties
-unrelated to the submission of our paper to ICRL. 
+This branch replicates the Contact Estimation experiment outlined in the paper ["On discrete symmetries of robotics systems: A group-theoretic and data-driven analysis"](https://arxiv.org/abs/2302.10433). See [Issue #9](https://github.com/Danfoa/MorphoSymm/issues/9) for more details.
 
-The code, dataset, and weights will be made public on a repository hosted on GitHub upon acceptance. 
-Expect changes to the code structure and API, as we intend to improve readability/usability and utility. 
-
-----------------------------------------------
-
-# On discrete symmetries of robotic systems: A data-driven and group-theoretic analysis
-
-![Morpholoigal symmetry states of the quadruped robot Solo](https://user-images.githubusercontent.com/8356912/191269534-af143f29-1f46-4009-858b-72a63b5c67ac.gif)
-
-A 3D interactive version of this animation is intended to be made public for all robots used in this project, functioning as an educational tool to have a clear understanding of the 
-morphological symmetries. For the moment a functional script for Solo and its K4 group can be run on `paper/robot_visualization.py`
-
-## Experiments 
-The script used to run the two experiments described in the paper is `train_supervised.py` which receives configuration files using `hydra`. 
-The default configurations can be found on the `cgf` directory. 
-All experiments were run in an HPC using `slurm`. The slurm jobs are not made public but the following are some examples of how to run the experiments on standard machines
-
-The `training_supervised` script will create an `experiment` directory on the project root folder, where the results of each individual run will be stored along with a tensorboard log file 
-holding several metrics logged during training and validation. After training is done, each model variant is evaluated on the test dataset and a log file `test_metrics.csv` is created 
-containing all evaluation metrics of the test set. These `test_metrics.csv` files for each of the model variants and individual seeds are used by the scripts in the `paper` directory 
-to generate several figures including the ones presented in the paper. 
-
-### CoM Estimation
-- Atlas: Example experiment training `mlp` and `emlp` models with `256`, `512`, and `1024` hidden channel neurons, with and without data augmentation.
+## Installation:
+First, install the following library:
 ```
-python train_supervised.py --multirun dataset=com_momentum dataset.samples=500000 model.num_channels=256,512,1024 exp_name=com_sample_eff robot_name=Atlas model=emlp,mlp dataset.train_ratio=0.70,0.3,0.1 model.lr=1.5e-3 model.inv_dims_sca dataset.augment=True,False$
-```
-- Solo with Morphological Symmetry Group C2 and K4
-```
-python train_supervised.py --multirun dataset=com_momentum exp_name=com_sample_eff robot_name=Solo,Solo-c2 model=emlp,mlp dataset.train_ratio=0.70 model.lr=2.4e-3 dataset.augment=True,False model.num_channels=64,128,256,512
+sudo aptitude install libnccl2
 ```
 
-### Static Friction Regime Contact Detection 
-- CNN
+Use the `conda_env.yml` file to create the conda environment:
+```
+conda env create -f conda_env.yml
+conda activate rss2023
+```
+
+## Import and Edit Submodule
+Run the following command:
+```
+git submodule init
+git submodule update --force --recursive --remote
+```
+
+Change lines 16 and 17 in "deep_contact_estimator/src/test.py" to the following:
+```
+from .contact_cnn import *
+from ..utils.data_handler import *
+```
+
+## Run experiments
+You'll need to run the commands below 8 times in order to generate the 8 random runs with different seeds.
+
+CNN & CNN-aug Experiments:
 ```
 python train_supervised.py --multirun dataset=contact dataset.data_folder=training_splitted exp_name=contact_sample_eff_splitted robot_name=mini-cheetah model=contact_cnn dataset.train_ratio=0.85 model.lr=1e-4 dataset.augment=True,False
 ```
-- ECNN
+
+ECNN Experiment:
 ```
 python train_supervised.py --multirun dataset=contact dataset.data_folder=training_splitted exp_name=contact_sample_eff_splitted robot_name=mini-cheetah model=contact_ecnn dataset.train_ratio=0.85 model.lr=1e-5 dataset.augment=False
+```
+
+## Generate Figures
+
+Paper Figure 4-Left & Center:
+
+TODO
+
+Paper Figure 4-Right:
+```
+python paper/contact_final_model_comparison.py
 ```

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -1,5 +1,6 @@
 name: rss2023
 channels:
+  - conda-forge
   - defaults
 dependencies:
   - _libgcc_mutex=0.1=main
@@ -35,7 +36,6 @@ dependencies:
       - cloudpickle==3.0.0
       - cmeel==0.53.3
       - cmeel-assimp==5.3.1
-      - cmeel-boost==1.83.0
       - cmeel-console-bridge==1.0.2.2
       - cmeel-octomap==1.9.8.2
       - cmeel-qhull==8.0.2.1
@@ -43,21 +43,17 @@ dependencies:
       - cmeel-urdfdom==3.1.1.1
       - contourpy==1.2.1
       - cycler==0.12.1
-      - eigenpy==3.5.1
       - emlp==1.0.3
       - etils==1.7.0
       - exceptiongroup==1.2.2
-      - filelock==3.15.4
       - fonttools==4.53.1
       - frozenlist==1.4.1
-      - fsspec==2024.6.1
       - gitdb==4.0.11
       - gitpython==3.1.43
       - grpcio==1.65.1
       - gym==0.26.2
       - gym-notices==0.0.8
       - h5py==3.11.0
-      - hpp-fcl==2.4.4
       - hydra-core==1.3.2
       - idna==3.7
       - iniconfig==2.0.0
@@ -78,27 +74,15 @@ dependencies:
       - multidict==6.0.5
       - networkx==3.3
       - numpy==1.24.4
-      - nvidia-cublas-cu12==12.1.3.1
-      - nvidia-cuda-cupti-cu12==12.1.105
-      - nvidia-cuda-nvrtc-cu12==12.1.105
-      - nvidia-cuda-runtime-cu12==12.1.105
       - nvidia-cudnn-cu12==8.9.2.26
-      - nvidia-cufft-cu12==11.0.2.54
-      - nvidia-curand-cu12==10.3.2.106
-      - nvidia-cusolver-cu12==11.4.5.107
-      - nvidia-cusparse-cu12==12.1.0.106
-      - nvidia-nccl-cu12==2.20.5
-      - nvidia-nvjitlink-cu12==12.5.82
-      - nvidia-nvtx-cu12==12.1.105
       - objax==1.8.0
       - omegaconf==2.3.0
       - opt-einsum==3.3.0
       - optax==0.2.3
       - packaging==24.1
-      - pandas==2.2.2
+      - pandas==1.5.2
       - parameterized==0.9.0
       - pillow==10.4.0
-      - pin==2.7.0
       - pluggy==1.5.0
       - plum-dispatch==2.5.2
       - protobuf==4.25.3
@@ -116,6 +100,7 @@ dependencies:
       - robot-descriptions==1.11.0
       - scikit-learn==1.5.1
       - scipy==1.9.0
+      - seaborn==0.13.2
       - six==1.16.0
       - smmap==5.0.1
       - strenum==0.4.15
@@ -128,10 +113,10 @@ dependencies:
       - toolz==0.12.1
       - torch==2.3.1
       - torchmetrics==1.4.0.post0
+      - torchvision==0.18.1
       - tqdm==4.66.4
       - triton==2.3.1
-      - typing-extensions==4.12.2
       - tzdata==2024.1
       - werkzeug==3.0.3
       - yarl==1.9.4
-prefix: /home/danfoa/anaconda3/envs/rss2023
+prefix: /home/dbutterfield3/miniconda3/envs/rss2023

--- a/paper/contact_final_model_comparison.py
+++ b/paper/contact_final_model_comparison.py
@@ -8,12 +8,9 @@ import seaborn as sns
 import pandas as pd
 import numpy as np
 import re
-from datasets.umich_contact_dataset import UmichContactDataset
 
-from utils.utils import cm2inch
-
-import re
-
+def cm2inch(cm):
+    return cm / 2.54
 
 def atoi(text):
     return int(text) if text.isdigit() else text
@@ -123,7 +120,7 @@ def split_run_name(run_name):
 if __name__ == "__main__":
     print(sys.argv, len(sys.argv))
 
-    experiments_path = 'experiments/contact_sample_eff_splitted_shuffled_mini-cheetah'
+    experiments_path = 'experiments/contact_sample_eff_splitted_mini-cheetah'
     # experiments_path = 'experiments/com_sample_eff_Solo-K4-C2'
     ignore_hps = [#['model=ECNN', 'augment=False'],
                   #['model=CNN', 'augment=True'],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-pytorch-lightning==1.9.3
-torch
-hydra-core
-emlp
-scipy==1.9.0   # Version for which sparse matrix API works with the current basis expansion code

--- a/tests/test_umich_contact_dataset.py
+++ b/tests/test_umich_contact_dataset.py
@@ -1,0 +1,99 @@
+import unittest
+import os
+import sys
+
+datasets_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(datasets_dir)
+
+from datasets.umich_contact_dataset import UmichContactDataset
+import torch
+import numpy as np
+
+class TestUmichContactDataset(unittest.TestCase):
+    """
+    Used to test methods in the UmichContactDataset.
+    """
+
+    def test_leg_f1_score_calculation(self):
+        """
+        Test that the Leg F1-Score calculation is correct, and matches up
+        with what is expected.
+        """
+
+        # Initialize the dataset class
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        dataset = UmichContactDataset(data_name="test.npy",
+                                        label_name="test_label.npy", train_ratio=0.85,
+                                        augment=False, use_class_imbalance_w=False,
+                                        window_size=150, device=device,
+                                        partition="training_splitted")
+        
+        # Define the input y_pred and y_gt
+        y_pred = torch.tensor(
+        [[7.18903254e-10, 9.13594135e-06, 7.33426063e-10, 9.32049961e-06,
+        4.77328554e-45, 6.06597015e-41, 4.86971231e-45, 6.18851088e-41,
+        3.89475642e-05, 4.94952082e-01, 3.97343572e-05, 5.04950778e-01,
+        2.58599254e-40, 3.28632206e-36, 2.63823305e-40, 3.35271017e-36,],
+        [0.00000000e+00, 3.43962697e-01, 0.00000000e+00, 1.47044198e-01,
+        0.00000000e+00, 3.43962697e-01, 0.00000000e+00, 1.47044198e-01,
+        0.00000000e+00, 6.29989654e-03, 0.00000000e+00, 2.69320844e-03,
+        0.00000000e+00, 6.29989654e-03, 0.00000000e+00, 2.69320844e-03,],
+        [2.49794350e-06, 1.83935391e-23, 1.00582507e-10, 7.40636555e-28,
+        1.65855385e-41, 1.22127162e-58, 6.67835376e-46, 4.91758765e-63,
+        9.99957238e-01, 7.36315795e-18, 4.02644037e-05, 2.96485842e-22,
+        6.63939327e-36, 4.88889920e-53, 2.67342643e-40, 1.96857029e-57,],
+        [0.00000000e+00, 6.87925393e-01, 0.00000000e+00, 2.94088397e-01,
+        0.00000000e+00, 1.69918285e-79, 0.00000000e+00, 7.26401388e-80,
+        0.00000000e+00, 1.25997931e-02, 0.00000000e+00, 5.38641688e-03,
+        0.00000000e+00, 3.11216195e-81, 0.00000000e+00, 1.33045055e-81,],
+        [5.88590171e-10, 7.47990117e-06, 6.00480482e-10, 7.63100520e-06,
+        3.90804874e-45, 4.96641293e-41, 3.98699656e-45, 5.06674112e-41,
+        3.89476945e-05, 4.94953738e-01, 3.97344901e-05, 5.04952467e-01,
+        2.58600119e-40, 3.28633305e-36, 2.63824188e-40, 3.35272138e-36,],
+        [0.00000000e+00, 6.23806791e-13, 0.00000000e+00, 1.93070537e-12,
+        0.00000000e+00, 6.23806791e-13, 0.00000000e+00, 1.93070537e-12,
+        0.00000000e+00, 1.22099006e-01, 0.00000000e+00, 3.77900994e-01,
+        0.00000000e+00, 1.22099006e-01, 0.00000000e+00, 3.77900994e-01,],
+        [2.04514409e-06, 1.50593630e-23, 8.23500287e-11, 6.06382199e-28,
+        1.35790966e-41, 9.99893089e-59, 5.46777608e-46, 4.02618206e-63,
+        9.99957690e-01, 7.36316129e-18, 4.02644219e-05, 2.96485977e-22,
+        6.63939628e-36, 4.88890141e-53, 2.67342764e-40, 1.96857118e-57,],
+        [0.00000000e+00, 1.24761358e-12, 0.00000000e+00, 3.86141073e-12,
+        0.00000000e+00, 3.08161848e-91, 0.00000000e+00, 9.53772453e-91,
+        0.00000000e+00, 2.44198012e-01, 0.00000000e+00, 7.55801988e-01,
+        0.00000000e+00, 6.03171621e-80, 0.00000000e+00, 1.86683874e-79,]], dtype=torch.float64, device=device)
+        y_gt = torch.tensor([15, 13, 6, 4, 3, 14, 8, 9], device=device)
+
+        # Run through the f1-score method
+        f1score_of_legs = dataset.calculate_f1_score_of_legs(y_pred, y_gt)
+
+        # Calculate the expected (using a different method for verification)
+        predictions = np.argmax(y_pred.cpu().numpy(), axis=1).astype(np.int64)
+        pred_b = np.array([list(np.binary_repr(x).rjust(4, '0')) for x in predictions], dtype=np.int64)
+        gt_b = np.array([list(np.binary_repr(x).rjust(4, '0')) for x in y_gt.cpu().numpy()], dtype=np.int64)
+
+        f1score_of_legs_des = []
+        for i in range(0, 4):
+            p = pred_b[:,i]
+            g = gt_b[:,i]
+
+            TP = np.sum([1 for p, g in zip(p, g) if p == 1 and g == 1])
+            FP = np.sum([1 for p, g in zip(p, g) if p == 1 and g == 0])
+            TN = np.sum([1 for p, g in zip(p, g) if p == 0 and g == 0])
+            FN = np.sum([1 for p, g in zip(p, g) if p == 0 and g == 1])
+
+            if TP + FP == 0: precision = 0
+            else: precision = TP / (TP + FP)
+
+            if TP + FN == 0: recall = 0
+            else: recall = TP / (TP + FN)
+
+            if precision + recall == 0: f1_score = 0
+            else: f1_score = 2 * precision * recall / (precision + recall)
+            f1score_of_legs_des.append(f1_score)
+
+        # Compare with the expected
+        np.testing.assert_array_equal(f1score_of_legs, f1score_of_legs_des)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request does two main things:

## Makes changes to facilitate generating Fig.4-Right by replicating the contact experiment.

- README.md was updated with specific instructions to ensure that the environment is properly setup and that python imports all work.
- conda_env.yml updated to remove conflicting libraries.
- Edited "contact_final_model_comparison.py" to have the proper experiment path.

## Fix a bug in the Binary Leg F1-Score calculation to ensure accurate comparisons.
According to [Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall), F1-score should be calculated as follows:
![image](https://github.com/user-attachments/assets/cd94f8eb-1abb-4b77-8fba-b9fc6129be30)

However, the previous code calculated it as such:
![image](https://github.com/user-attachments/assets/2d360828-d675-47f2-afc7-58d7f6f907a3)

Therefore:
- Corrects the Binary Leg F1-Score Calculation (and by extension, the Legs Avg Binary F1-Score).
- Wrote a test case to verify that the Binary Leg F1-Score was calculated correctly.